### PR TITLE
fix stylesheet path

### DIFF
--- a/templates/Wilr/GoogleSitemaps/Control/GoogleSitemapController_sitemap.ss
+++ b/templates/Wilr/GoogleSitemaps/Control/GoogleSitemapController_sitemap.ss
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-stylesheet type='text/xsl' href='{$BaseHref}sitemap.xml/styleSheet'?>
+<?xml-stylesheet type='text/xsl' href='{$AbsoluteBaseURL}/sitemap.xml/styleSheet'?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
         xmlns:image="http://www.google.com/schemas/sitemap-image/1.1"
         xmlns:xhtml="http://www.w3.org/1999/xhtml"


### PR DESCRIPTION
align with original template https://github.com/wilr/silverstripe-googlesitemaps/blob/main/templates/Wilr/GoogleSitemaps/Control/GoogleSitemapController_sitemap.ss

without this, it doesn't work in ss5

it may even require some further work down the road:
https://github.com/wilr/silverstripe-googlesitemaps/commit/81b8d870a453abad0858859113bd07dcf42a4447